### PR TITLE
Fix typo in packet capture duration comment

### DIFF
--- a/NetworkEnum.sh
+++ b/NetworkEnum.sh
@@ -142,7 +142,7 @@ function TCPDump() {
 		*) echo "invalid response";;
 	esac
 
-	#Get lenght of time to perform packet capture
+	#Get length of time to perform packet capture
 	read -p "Enter capture time length in seconds (greater than 30 less than 900): " tcpDumpTime
 
 


### PR DESCRIPTION
## Summary
- fix spelling of packet capture duration comment in `NetworkEnum.sh`

## Testing
- `shellcheck NetworkEnum.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository '... InRelease' not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c093ac108326bfda15f0c1362ef2