### PR TITLE
Add Bats tests for root detection and command building

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Network protocol analysis script for Kali Linux
 1. Install dependencies <br />
 2. Run setup (Option 1), this is not persistent so you will need to reenter it each time you run the script. <br />
 3. choose Unauth Network Info Gather or  TCPDump and parse to begin with. All output is displayed and files saved in the local folder. <br />
+4. Run `bats tests` to execute the test suite and verify functionality. <br />
 
 <br />
 # Example

--- a/tests/network_enum.bats
+++ b/tests/network_enum.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+@test "is_user_root returns success for root user" {
+  source <(sed -n '18,22p' NetworkEnum.sh)
+  run is_user_root
+  [ "$status" -eq 0 ]
+}
+
+@test "is_user_root returns failure for non-root user" {
+  run sudo -u nobody bash -c 'source <(sed -n "18,22p" NetworkEnum.sh); is_user_root'
+  [ "$status" -ne 0 ]
+}
+
+@test "ping_scan builds nmap command" {
+  source <(sed -n '46,53p' NetworkEnum.sh)
+  date() { echo "01-02-2006-jan-15-04-05"; }
+  nmap() { echo "$@" > cmd.out; }
+  ping_scan "targets.txt"
+  run cat cmd.out
+  [ "$output" = "-sP -PE -iL targets.txt -oA Client_pingscan-01-02-2006-jan-15-04-05" ]
+  rm cmd.out
+}
+
+@test "dns_zone_transfer builds dnsrecon command" {
+  source <(sed -n '76,80p' NetworkEnum.sh)
+  date() { echo "01-02-2006-jan-15-04-05"; }
+  dnsrecon() { echo "$@" > cmd.out; }
+  dns_zone_transfer "example.com"
+  run cat cmd.out
+  [ "$output" = "-d example.com -a --xml Client_zone_transfer-01-02-2006-jan-15-04-05.xml" ]
+  rm cmd.out
+}


### PR DESCRIPTION
## Summary
- add Bats tests covering root detection and command construction for nmap and dnsrecon
- document how to run the Bats test suite

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c09e24f8832680518ae54c57d3ad